### PR TITLE
Respect cancelled events, (and add auto package actions script)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,33 @@
+name: Create Plugin.jar
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Project
+        uses: actions/checkout@v4
+      - name: Setting Up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: maven
+      - name: Build and Package Plugin
+        run: |
+          artifactPath="$(pwd)/target"
+          artifactName="$(mvn help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)"
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "artifactPath=${artifactPath}" >> $GITHUB_ENV
+          echo "artifactName=${artifactName}" >> $GITHUB_ENV
+          echo git_hash=${git_hash} >> $GITHUB_ENV
+          mvn clean package
+          mv "${artifactPath}/${artifactName}.jar" "${artifactPath}/${artifactName}-${git_hash}.jar"
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.artifactName }}-${{ env.git_hash }}.jar
+          path: ${{ env.artifactPath }}/${{ env.artifactName }}-${{ env.git_hash }}.jar

--- a/ClickVillagers.iml
+++ b/ClickVillagers.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+<module version="4">
   <component name="FacetManager">
     <facet type="minecraft" name="Minecraft">
       <configuration>
@@ -8,28 +8,5 @@
         </autoDetectTypes>
       </configuration>
     </facet>
-  </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
-    <output url="file://$MODULE_DIR$/target/classes" />
-    <output-test url="file://$MODULE_DIR$/target/test-classes" />
-    <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
-    </content>
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:guava:31.1-jre" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:failureaccess:1.0.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker-qual:3.12.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.errorprone:error_prone_annotations:2.11.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.j2objc:j2objc-annotations:1.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.gson:gson:2.10" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.joml:joml:1.10.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.md-5:bungeecord-chat:1.20-R0.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.yaml:snakeyaml:2.0" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
 
     <repositories>
         <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+        <repository>
             <id>spigotmc-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
@@ -69,6 +73,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.angeschossen</groupId>
+            <artifactId>LandsAPI</artifactId>
+            <version>7.0.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/clickism/clickvillagers/ClickVillagers.java
+++ b/src/main/java/me/clickism/clickvillagers/ClickVillagers.java
@@ -3,6 +3,7 @@ package me.clickism.clickvillagers;
 import me.clickism.clickvillagers.config.Messages;
 import me.clickism.clickvillagers.config.Settings;
 import me.clickism.clickvillagers.events.*;
+import me.clickism.clickvillagers.integrations.LandsHook;
 import me.clickism.clickvillagers.managers.HopperManager;
 import me.clickism.clickvillagers.managers.VillagerData;
 import me.clickism.clickvillagers.managers.VillagerManager;
@@ -19,6 +20,11 @@ public final class ClickVillagers extends JavaPlugin {
     private static ConfigManager config;
     private static MessageManager messages;
     private static String version;
+
+    @Override
+    public void onLoad(){
+        new LandsHook(this);
+    }
 
     @Override
     public void onEnable() {

--- a/src/main/java/me/clickism/clickvillagers/events/BlockEvent.java
+++ b/src/main/java/me/clickism/clickvillagers/events/BlockEvent.java
@@ -24,7 +24,7 @@ public class BlockEvent implements Listener {
         plugin = pl;
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onPlace(BlockPlaceEvent e) {
         if (e.getBlockPlaced().getType() == Material.PLAYER_HEAD || e.getBlockPlaced().getType() == Material.PLAYER_WALL_HEAD) {
             //Place villager back
@@ -79,7 +79,7 @@ public class BlockEvent implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onBreak(BlockBreakEvent e) {
         if (e.getBlock().getType() == Material.HOPPER) {
             if (HopperManager.isVillagerHopper(e.getBlock().getLocation())) {

--- a/src/main/java/me/clickism/clickvillagers/events/BlockEvent.java
+++ b/src/main/java/me/clickism/clickvillagers/events/BlockEvent.java
@@ -3,6 +3,7 @@ package me.clickism.clickvillagers.events;
 import me.clickism.clickvillagers.*;
 import me.clickism.clickvillagers.config.Messages;
 import me.clickism.clickvillagers.config.Settings;
+import me.clickism.clickvillagers.integrations.LandsHook;
 import me.clickism.clickvillagers.managers.HopperManager;
 import me.clickism.clickvillagers.managers.VillagerData;
 import me.clickism.clickvillagers.managers.VillagerManager;
@@ -12,6 +13,7 @@ import org.bukkit.block.Hopper;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -24,8 +26,12 @@ public class BlockEvent implements Listener {
         plugin = pl;
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     public void onPlace(BlockPlaceEvent e) {
+
+        if(LandsHook.isEnabled() && !LandsHook.hasVillagerFlag(e.getPlayer(), e.getBlock().getLocation())) return;
+        if(e.isCancelled() && !LandsHook.isEnabled()) return;
+
         if (e.getBlockPlaced().getType() == Material.PLAYER_HEAD || e.getBlockPlaced().getType() == Material.PLAYER_WALL_HEAD) {
             //Place villager back
             if (!VillagerManager.isVillagerHead(e.getItemInHand())) return;

--- a/src/main/java/me/clickism/clickvillagers/events/InteractEvent.java
+++ b/src/main/java/me/clickism/clickvillagers/events/InteractEvent.java
@@ -22,7 +22,7 @@ import org.bukkit.potion.PotionEffectType;
 
 public class InteractEvent implements Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onPlayerInteractEntity(PlayerInteractEntityEvent e) {
         if (e.getHand().equals(EquipmentSlot.OFF_HAND)) return;
         if (e.getRightClicked() instanceof Villager || e.getRightClicked() instanceof ZombieVillager) {

--- a/src/main/java/me/clickism/clickvillagers/events/InteractEvent.java
+++ b/src/main/java/me/clickism/clickvillagers/events/InteractEvent.java
@@ -3,6 +3,7 @@ package me.clickism.clickvillagers.events;
 import me.clickism.clickvillagers.Utils;
 import me.clickism.clickvillagers.config.Messages;
 import me.clickism.clickvillagers.config.Settings;
+import me.clickism.clickvillagers.integrations.LandsHook;
 import me.clickism.clickvillagers.managers.VillagerData;
 import me.clickism.clickvillagers.managers.VillagerManager;
 import me.clickism.clickvillagers.menu.ClaimVillagerMenu;
@@ -22,8 +23,12 @@ import org.bukkit.potion.PotionEffectType;
 
 public class InteractEvent implements Listener {
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     public void onPlayerInteractEntity(PlayerInteractEntityEvent e) {
+
+        if(LandsHook.isEnabled() && !LandsHook.hasVillagerFlag(e.getPlayer(), e.getRightClicked().getLocation())) return;
+        if(e.isCancelled() && !LandsHook.isEnabled()) return;
+
         if (e.getHand().equals(EquipmentSlot.OFF_HAND)) return;
         if (e.getRightClicked() instanceof Villager || e.getRightClicked() instanceof ZombieVillager) {
             LivingEntity entity = (LivingEntity) e.getRightClicked();

--- a/src/main/java/me/clickism/clickvillagers/integrations/LandsHook.java
+++ b/src/main/java/me/clickism/clickvillagers/integrations/LandsHook.java
@@ -1,0 +1,44 @@
+package me.clickism.clickvillagers.integrations;
+
+import me.angeschossen.lands.api.LandsIntegration;
+import me.angeschossen.lands.api.flags.enums.FlagTarget;
+import me.angeschossen.lands.api.flags.enums.RoleFlagCategory;
+import me.angeschossen.lands.api.flags.type.RoleFlag;
+import me.angeschossen.lands.api.land.LandWorld;
+import me.clickism.clickvillagers.ClickVillagers;
+import me.clickism.clickvillagers.managers.SkullManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class LandsHook {
+
+    private static boolean hasLands = false;
+    private static LandsIntegration landsApi;
+    private static RoleFlag clickVillagersFlag;
+
+    public LandsHook(ClickVillagers plugin){
+        hasLands = Bukkit.getPluginManager().getPlugin("Lands") != null;
+        if(!hasLands) return;
+
+        plugin.getLogger().info("Lands plugin found - Added a ClickVillagers RoleFlag");
+        landsApi = LandsIntegration.of(plugin);
+        clickVillagersFlag = RoleFlag.of(landsApi, FlagTarget.PLAYER, RoleFlagCategory.ACTION, "click_villagers");
+        clickVillagersFlag
+                .setDisplayName("Pick & Place Villagers")
+                .setIcon(SkullManager.getGenericHeadItem())
+                .setDescription("Allow a player to pick up and place villagers");
+    }
+
+    public static boolean isEnabled(){
+        return hasLands;
+    }
+
+    public static boolean hasVillagerFlag(Player player, Location location){
+        final LandWorld world = landsApi.getWorld(player.getWorld());
+        if(world == null) return true;
+        return world.hasRoleFlag(player.getUniqueId(), location, clickVillagersFlag);
+    }
+}

--- a/src/main/java/me/clickism/clickvillagers/managers/SkullManager.java
+++ b/src/main/java/me/clickism/clickvillagers/managers/SkullManager.java
@@ -16,6 +16,21 @@ import java.util.UUID;
 
 public class SkullManager {
 
+    public static ItemStack getGenericHeadItem(){
+        ItemStack item = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta meta = (SkullMeta) item.getItemMeta();
+        if (meta == null) {
+            meta = (SkullMeta) Bukkit.getServer().getItemFactory().getItemMeta(Material.PLAYER_HEAD);
+        }
+        try {
+            PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID());
+            profile.getTextures().setSkin(new URL("http://textures.minecraft.net/texture/35e799dbfaf98287dfbafce970612c8f075168977aacc30989d34a4a5fcdf429"));
+            meta.setOwnerProfile(profile);
+        } catch (MalformedURLException ignored) {}
+        item.setItemMeta(meta);
+        return item;
+    }
+
     public static ItemStack getVillagerHeadItem(LivingEntity entity){
         ItemStack item = new ItemStack(Material.PLAYER_HEAD);
         SkullMeta meta = (SkullMeta) item.getItemMeta();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: '0.4.3'
 main: me.clickism.clickvillagers.ClickVillagers
 api-version: '1.20'
 authors: [Clickism]
+softdepend: [Lands]
 description: A simple plugin that makes handling villagers a lot easier
 permissions:
   clickvillagers.pickup:


### PR DESCRIPTION
Fixes https://github.com/Clickism/ClickVillagers/issues/13

All that was needed was for you to ignore canceled events. This should theoretically add support for a lot of other claims/region based plugins that cancel events.

I also included workflow script of mine that uses github actions that will automatically package the repo into a jar everytime you push to the repo.