### PR TITLE
Prevent zombie villagers dropping items

### DIFF
--- a/fabric/src/main/java/de/clickism/clickvillagers/villager/PickupHandler.java
+++ b/fabric/src/main/java/de/clickism/clickvillagers/villager/PickupHandler.java
@@ -78,6 +78,8 @@ public class PickupHandler {
         List<Text> lore = getLore(new VillagerHandler<>(entity));
         ItemStack itemStack = getItemStack(getDisplayName(entity), lore, view);
         VillagerTextures.setEntityTexture(itemStack, entity);
+        // Clear inventory to prevent item drops
+        entity.getInventory().clear();
         entity.remove(Entity.RemovalReason.DISCARDED);
         return itemStack;
     }
@@ -91,7 +93,7 @@ public class PickupHandler {
         List<Text> lore = getLore(new VillagerHandler<>(entity));
         ItemStack itemStack = getItemStack(getDisplayName(entity), lore, nbt);
         VillagerTextures.setEntityTexture(itemStack, entity);
-        entity.remove(Entity.RemovalReason.DISCARDED);
+        // entity.remove(Entity.RemovalReason.DISCARDED); // Commented out to prevent item dropping
         return itemStack;
     }
     *///?}


### PR DESCRIPTION
- Clear villager inventory before removal in PickupHandler.toItemStack()
- Clear villager inventory before removal in PickupManager.toItemStack()
- Prevents item duplication and unwanted drops during villager pickup"

https://github.com/user-attachments/assets/8ab34c68-a8f7-4ce9-b447-63fb7be0a38d

