### PR TITLE
Fix infinite discount exploit using illegal client modifications

### DIFF
--- a/paper/src/main/java/de/clickism/clickvillagers/gui/VillagerEditMenu.java
+++ b/paper/src/main/java/de/clickism/clickvillagers/gui/VillagerEditMenu.java
@@ -47,7 +47,9 @@ public class VillagerEditMenu extends Menu {
                     if (!CLAIMED_VILLAGERS_BYPASS_PERMISSIONS.get()) {
                         if (Permission.PICKUP.lacksAndNotify(player)) return;
                     }
-                    Utils.setHandOrGive(player, pickupManager.toItemStack(villager));
+                    var itemResult = pickupManager.toItemStack(villager);
+                    if (itemResult.isEmpty()) return;
+                    Utils.setHandOrGive(player, itemResult.get());
                     PICK_UP_VILLAGER.sendActionbarSilently(player);
                     pickupManager.sendPickupEffect(villager);
                 }));

--- a/paper/src/main/java/de/clickism/clickvillagers/hopper/HopperTicker.java
+++ b/paper/src/main/java/de/clickism/clickvillagers/hopper/HopperTicker.java
@@ -117,8 +117,8 @@ public class HopperTicker {
         for (LivingEntity villager : villagers) {
             if (emptySlots <= 0) break;
             try {
-                ItemStack item = pickupManager.toItemStack(villager);
-                inventory.addItem(item);
+                var itemResult = pickupManager.toItemStack(villager);
+                itemResult.ifPresent(inventory::addItem);
             } catch (Exception exception) {
                 ClickVillagers.LOGGER.severe("Failed to write villager data: " + exception.getMessage());
             }

--- a/paper/src/main/java/de/clickism/clickvillagers/listener/InteractListener.java
+++ b/paper/src/main/java/de/clickism/clickvillagers/listener/InteractListener.java
@@ -212,7 +212,9 @@ public class InteractListener implements Listener {
         }
         ItemStack item;
         try {
-            item = pickupManager.toItemStack(villager);
+            var itemResult = pickupManager.toItemStack(villager);
+            if (itemResult.isEmpty()) return;
+            item = itemResult.get();
         } catch (IllegalArgumentException exception) {
             Message.WRITE_ERROR.send(player);
             ClickVillagers.LOGGER.severe("Failed to write villager data: " + exception.getMessage());

--- a/paper/src/main/java/de/clickism/clickvillagers/villager/PickupManager.java
+++ b/paper/src/main/java/de/clickism/clickvillagers/villager/PickupManager.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 import static de.clickism.clickvillagers.ClickVillagersConfig.*;
 import static de.clickism.clickvillagers.message.Message.VILLAGER_WITH_PROFESSION;
@@ -106,14 +107,21 @@ public class PickupManager implements Listener {
     }
 
     @NotNull
-    public ItemStack toItemStack(LivingEntity entity) throws IllegalArgumentException {
+    public Optional<ItemStack> toItemStack(LivingEntity entity) throws IllegalArgumentException {
         if (!(entity instanceof Villager) && !(entity instanceof ZombieVillager)) {
             throw new IllegalArgumentException("Entity is not a villager");
+        }
+        if (entity instanceof Villager villager && villager.isTrading()) {
+            var trader = villager.getTrader();
+            if (trader != null) {
+                trader.closeInventory();
+            }
+            return Optional.empty();
         }
         ItemStack item = createItem(entity);
         writeData(entity, item);
         entity.remove();
-        return item;
+        return Optional.of(item);
     }
 
     private ItemResult getHeldVillagerItem(PlayerInventory inventory) {

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ClickVillagers
 version: '${version}'
 main: de.clickism.clickvillagers.ClickVillagers
 api-version: '1.21'
-authors: [Clickism]
+authors: [Clickism, Sylvye]
 description: A simple plugin that makes handling villagers a lot easier
 folia-supported: true
 commands:


### PR DESCRIPTION
# Prevents temporary player-specific villager discounts from being serialized when picking up a villager during an active trade session.

A modified client could suppress the merchant close packet, pick up the villager, and place it again. This persisted the active `specialPrice`, causing the discount to be applied repeatedly.

- Block villager serialization while `Villager.isTrading()` is true.
- Force-close the server-side inventory of the active trader.
- Require another interaction before pickup can proceed.
- Handle blocked pickups safely for:
  - Direct sneak-right-click pickup
  - Claimed-villager menu pickup
  - Villager hoppers
- Add Sylvye to the Paper plugin author metadata. :)

This only changes the Paper implementation. Fabric and NeoForge behavior is unaffected.